### PR TITLE
Added lifecycle-mapping-metadata to support m2e in eclipse

### DIFF
--- a/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -7,8 +7,7 @@
 				</goals>
 			</pluginExecutionFilter>
 			<action>
-				<runOnIncremental>true</runOnIncremental>
-				<runOnConfiguration>true</runOnConfiguration>
+				<ignore />
 			</action>
 		</pluginExecution>
 	</pluginExecutions>


### PR DESCRIPTION
Eclipse builds will be configured to ignore the plugin
